### PR TITLE
refactor: 통화방 목록 조회 시 createdAt, host 필드 함께 반환

### DIFF
--- a/src/call-rooms/dto/core/response/GetCallRoomsResponse.interface.ts
+++ b/src/call-rooms/dto/core/response/GetCallRoomsResponse.interface.ts
@@ -71,7 +71,7 @@ export interface CallRoomSummaryResponse {
   isPublic: boolean;
   hasPassword: boolean;
   thumbnailUrl: string | null;
-  createdAt: Date;
+  createdAt: string;
   host: HostSummaryResponse;
 }
 

--- a/src/call-rooms/dto/core/response/GetCallRoomsResponse.interface.ts
+++ b/src/call-rooms/dto/core/response/GetCallRoomsResponse.interface.ts
@@ -56,6 +56,12 @@
 }
 */
 
+export interface HostSummaryResponse {
+  userIdx: number;
+  userName: string;
+  profileUrl: string;
+}
+
 export interface CallRoomSummaryResponse {
   roomIdx: number;
   title: string;
@@ -65,7 +71,8 @@ export interface CallRoomSummaryResponse {
   isPublic: boolean;
   hasPassword: boolean;
   thumbnailUrl: string | null;
-  hostUserIdx: number;
+  createdAt: Date;
+  host: HostSummaryResponse;
 }
 
 export interface PageSortResponse {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 통화방 목록에서 호스트 정보 표시를 개선해 호스트의 이름, 식별자와 프로필 이미지를 함께 제공합니다.
  * 통화방에 생성 시각(날짜/시간)을 추가해 정렬 및 확인이 용이해졌습니다.
  * 목록 UI에서 호스트·생성 시점 정보로 방을 더 직관적으로 식별할 수 있습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3-1-ChoiInSawMan/gesture_NestJS_Backend/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->