### PR TITLE
fix: 프레임 전송을 통화방 기준으로 처리

### DIFF
--- a/src/calls/calls.gateway.ts
+++ b/src/calls/calls.gateway.ts
@@ -8,6 +8,7 @@ import { disconnectWithAuthError } from 'src/common/ws-error.util';
 import { WsGuard } from 'src/guards/ws.guard';
 import { CallsService } from './calls.service';
 import { CallRoomPayloadDto, SignalingPayloadDto } from './dto/call-signaling.dto';
+import { SendFrameDto } from './dto/send-frame.dto';
 
 @WebSocketGateway({
   namespace: '/calls'
@@ -26,10 +27,10 @@ export class CallsGateway implements OnGatewayConnection, OnGatewayDisconnect, O
   @UseGuards(WsGuard)
   @SubscribeMessage('send_frame')
   handleSendFrame(
-    @MessageBody() frame: object,
+    @MessageBody() payload: SendFrameDto,
     @ConnectedSocket() client: Socket
   ) {
-    this.callsService.sendFrame(frame, client);
+    this.callsService.sendFrame(payload, client);
   }
 
   @UseGuards(WsGuard)

--- a/src/calls/calls.service.ts
+++ b/src/calls/calls.service.ts
@@ -7,9 +7,10 @@ import { ConfigService } from '@nestjs/config';
 import WebSocket, { RawData } from 'ws';
 import type { Server, Socket } from 'socket.io';
 import { Logger } from 'nestjs-pino';
-import { disconnectWithAuthError } from 'src/common/ws-error.util';
+import { disconnectWithAuthError, emitWsError } from 'src/common/ws-error.util';
 import { AiMessageDto } from './dto/ai-message.dto';
 import { SignalingPayloadDto } from './dto/call-signaling.dto';
+import { SendFrameDto } from './dto/send-frame.dto';
 
 type SignalingEvent = 'offer' | 'answer' | 'ice_candidate';
 
@@ -19,6 +20,7 @@ export class CallsService {
 
   private readonly clients = new Map<string, Socket>();
   private readonly clientParticipants = new Map<number, number>();
+  private readonly pendingFrameUserIdxs = new Map<number, number[]>();
 
   private aiSocket?: WebSocket;
   private server?: Server;
@@ -203,7 +205,7 @@ export class CallsService {
     const { callRoomIdx } = payload;
 
     if (!this.isValidCallRoomIdx(callRoomIdx) || !client.rooms.has(this.getCallRoomName(callRoomIdx))) {
-      disconnectWithAuthError(client, 'CALL_002');
+      emitWsError(client, 'CALL_002');
 
       return;
     }
@@ -231,8 +233,18 @@ export class CallsService {
 
     const { text, callRoomIdx } = parseData;
 
-    if (typeof text !== 'string' || text.length === 0 || !Number.isInteger(callRoomIdx)) {
-      this.logger.warn({ parseData }, 'Dropped invalid AI message');
+    if (
+      typeof text !== 'string'
+      || text.length === 0
+      || !this.isValidCallRoomIdx(callRoomIdx)
+    ) {
+      return;
+    }
+
+    const userIdx = this.shiftPendingFrameUserIdx(callRoomIdx);
+
+    if (!Number.isInteger(userIdx)) {
+      this.logger.warn({ parseData }, 'Dropped AI message without matching frame sender');
 
       return;
     }
@@ -243,18 +255,28 @@ export class CallsService {
       return;
     }
     
-    this.server.to(`call_room:${callRoomIdx}`).emit('translation', {
+    this.server.to(this.getCallRoomName(callRoomIdx)).emit('translation', {
       text,
-      callRoomIdx
+      callRoomIdx,
+      userIdx,
     });
   }
 
   public sendFrame(
-    frame: object,
+    payload: SendFrameDto,
     client: Socket
   ) {
-    if (!this.isValidCallRoomIdx(client.data.callRoomIdx)) {
-      disconnectWithAuthError(client, 'CALL_002');
+    const { frame, callRoomIdx } = payload;
+    const userIdx = this.getClientUserIdx(client);
+
+    if (!Number.isInteger(userIdx)) {
+      emitWsError(client, 'AUTH_001');
+
+      return;
+    }
+
+    if (!this.isValidCallRoomIdx(callRoomIdx) || !client.rooms.has(this.getCallRoomName(callRoomIdx))) {
+      emitWsError(client, 'CALL_002');
 
       return;
     }
@@ -265,13 +287,16 @@ export class CallsService {
       return;
     }
 
+    this.pushPendingFrameUserIdx(callRoomIdx, userIdx);
+
     this.aiSocket.send(
       JSON.stringify({
         frame,
-        callRoomIdx: client.data.callRoomIdx,
+        callRoomIdx,
       }),
       (error) => {
         if (error) {
+          this.removePendingFrameUserIdx(callRoomIdx, userIdx);
           this.logger.error({ err: error }, 'AI WebSocket send failed');
         }
       },
@@ -352,6 +377,65 @@ export class CallsService {
       socketId: client.id,
       userIdx: client.data.user?.idx,
     };
+  }
+
+  private getClientUserIdx(
+    client: Socket
+  ) {
+    const userIdx = client.data.user?.idx;
+
+    if (Number.isInteger(userIdx)) {
+      return userIdx;
+    }
+  }
+
+  private pushPendingFrameUserIdx(
+    callRoomIdx: number,
+    userIdx: number
+  ) {
+    const userIdxs = this.pendingFrameUserIdxs.get(callRoomIdx) ?? [];
+
+    userIdxs.push(userIdx);
+    this.pendingFrameUserIdxs.set(callRoomIdx, userIdxs);
+  }
+
+  private shiftPendingFrameUserIdx(
+    callRoomIdx: number
+  ) {
+    const userIdxs = this.pendingFrameUserIdxs.get(callRoomIdx);
+
+    if (!userIdxs || userIdxs.length === 0) {
+      return;
+    }
+
+    const userIdx = userIdxs.shift();
+
+    if (userIdxs.length === 0) {
+      this.pendingFrameUserIdxs.delete(callRoomIdx);
+    }
+
+    return userIdx;
+  }
+
+  private removePendingFrameUserIdx(
+    callRoomIdx: number,
+    userIdx: number
+  ) {
+    const userIdxs = this.pendingFrameUserIdxs.get(callRoomIdx);
+
+    if (!userIdxs) {
+      return;
+    }
+
+    const index = userIdxs.indexOf(userIdx);
+
+    if (index !== -1) {
+      userIdxs.splice(index, 1);
+    }
+
+    if (userIdxs.length === 0) {
+      this.pendingFrameUserIdxs.delete(callRoomIdx);
+    }
   }
 
   private toRecord(

--- a/src/calls/calls.service.ts
+++ b/src/calls/calls.service.ts
@@ -14,17 +14,23 @@ import { SendFrameDto } from './dto/send-frame.dto';
 
 type SignalingEvent = 'offer' | 'answer' | 'ice_candidate';
 
+type PendingFrameRequest = {
+  requestId: number;
+  userIdx: number;
+};
+
 @Injectable()
 export class CallsService {
   private readonly AI_WS_URL: string;
 
   private readonly clients = new Map<string, Socket>();
   private readonly clientParticipants = new Map<number, number>();
-  private readonly pendingFrameUserIdxs = new Map<number, number[]>();
+  private readonly pendingFrameRequests = new Map<number, PendingFrameRequest[]>();
 
   private aiSocket?: WebSocket;
   private server?: Server;
 
+  private nextFrameRequestId = 0;
   private reconnectTimer?: NodeJS.Timeout;
   private reconnectAttempts = 0;
   private isShuttingDown = false;
@@ -87,6 +93,7 @@ export class CallsService {
       );
 
       this.aiSocket = undefined;
+      this.clearPendingFrameRequests();
 
       this.scheduleAiReconnect();
     });
@@ -241,9 +248,9 @@ export class CallsService {
       return;
     }
 
-    const userIdx = this.shiftPendingFrameUserIdx(callRoomIdx);
+    const pendingFrameRequest = this.shiftPendingFrameRequest(callRoomIdx);
 
-    if (!Number.isInteger(userIdx)) {
+    if (!pendingFrameRequest) {
       this.logger.warn({ parseData }, 'Dropped AI message without matching frame sender');
 
       return;
@@ -258,7 +265,7 @@ export class CallsService {
     this.server.to(this.getCallRoomName(callRoomIdx)).emit('translation', {
       text,
       callRoomIdx,
-      userIdx,
+      userIdx: pendingFrameRequest.userIdx,
     });
   }
 
@@ -287,7 +294,7 @@ export class CallsService {
       return;
     }
 
-    this.pushPendingFrameUserIdx(callRoomIdx, userIdx);
+    const requestId = this.pushPendingFrameRequest(callRoomIdx, userIdx);
 
     this.aiSocket.send(
       JSON.stringify({
@@ -296,7 +303,7 @@ export class CallsService {
       }),
       (error) => {
         if (error) {
-          this.removePendingFrameUserIdx(callRoomIdx, userIdx);
+          this.removePendingFrameRequest(callRoomIdx, requestId);
           this.logger.error({ err: error }, 'AI WebSocket send failed');
         }
       },
@@ -389,53 +396,70 @@ export class CallsService {
     }
   }
 
-  private pushPendingFrameUserIdx(
+  private pushPendingFrameRequest(
     callRoomIdx: number,
     userIdx: number
   ) {
-    const userIdxs = this.pendingFrameUserIdxs.get(callRoomIdx) ?? [];
+    const requestId = this.createFrameRequestId();
+    const requests = this.pendingFrameRequests.get(callRoomIdx) ?? [];
 
-    userIdxs.push(userIdx);
-    this.pendingFrameUserIdxs.set(callRoomIdx, userIdxs);
+    requests.push({
+      requestId,
+      userIdx,
+    });
+
+    this.pendingFrameRequests.set(callRoomIdx, requests);
+
+    return requestId;
   }
 
-  private shiftPendingFrameUserIdx(
+  private shiftPendingFrameRequest(
     callRoomIdx: number
   ) {
-    const userIdxs = this.pendingFrameUserIdxs.get(callRoomIdx);
+    const requests = this.pendingFrameRequests.get(callRoomIdx);
 
-    if (!userIdxs || userIdxs.length === 0) {
+    if (!requests || requests.length === 0) {
       return;
     }
 
-    const userIdx = userIdxs.shift();
+    const request = requests.shift();
 
-    if (userIdxs.length === 0) {
-      this.pendingFrameUserIdxs.delete(callRoomIdx);
+    if (requests.length === 0) {
+      this.pendingFrameRequests.delete(callRoomIdx);
     }
 
-    return userIdx;
+    return request;
   }
 
-  private removePendingFrameUserIdx(
+  private removePendingFrameRequest(
     callRoomIdx: number,
-    userIdx: number
+    requestId: number
   ) {
-    const userIdxs = this.pendingFrameUserIdxs.get(callRoomIdx);
+    const requests = this.pendingFrameRequests.get(callRoomIdx);
 
-    if (!userIdxs) {
+    if (!requests) {
       return;
     }
 
-    const index = userIdxs.indexOf(userIdx);
+    const index = requests.findIndex((request) => request.requestId === requestId);
 
     if (index !== -1) {
-      userIdxs.splice(index, 1);
+      requests.splice(index, 1);
     }
 
-    if (userIdxs.length === 0) {
-      this.pendingFrameUserIdxs.delete(callRoomIdx);
+    if (requests.length === 0) {
+      this.pendingFrameRequests.delete(callRoomIdx);
     }
+  }
+
+  private clearPendingFrameRequests() {
+    this.pendingFrameRequests.clear();
+  }
+
+  private createFrameRequestId() {
+    this.nextFrameRequestId = (this.nextFrameRequestId % Number.MAX_SAFE_INTEGER) + 1;
+
+    return this.nextFrameRequestId;
   }
 
   private toRecord(

--- a/src/calls/dto/send-frame.dto.ts
+++ b/src/calls/dto/send-frame.dto.ts
@@ -1,0 +1,32 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, Min, Validate, ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+
+export type FramePoint = [number, number];
+
+@ValidatorConstraint({ name: 'isFramePointArray', async: false })
+class IsFramePointArrayConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown) {
+    return Array.isArray(value)
+      && value.length > 0
+      && value.every((point) => (
+        Array.isArray(point)
+        && point.length === 2
+        && point.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate))
+      ));
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return `${args.property} must be a non-empty array of [number, number] points`;
+  }
+}
+
+export class SendFrameDto {
+  @IsArray()
+  @Validate(IsFramePointArrayConstraint)
+  frame: FramePoint[];
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  callRoomIdx: number;
+}

--- a/src/common/ws-error.util.ts
+++ b/src/common/ws-error.util.ts
@@ -3,14 +3,21 @@ import { Socket } from 'socket.io';
 
 export type ErrorCodeKey = keyof typeof ErrorCode;
 
+export function emitWsError(
+  client: Socket,
+  statusCode: ErrorCodeKey
+) {
+  client.emit('ws_error', {
+    statusCode,
+    message: ErrorCode[statusCode]
+  });
+}
+
 export function disconnectWithAuthError(
   client: Socket,
   statusCode: ErrorCodeKey
 ) {
-  client.emit('error', {
-    statusCode,
-    message: ErrorCode[statusCode]
-  });
+  emitWsError(client, statusCode);
 
   client.disconnect(true);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 프레임 데이터와 호출 룸 ID에 대한 입력 유효성 검사 강화
  * AI 번역 응답을 개별 요청(대기 큐)과 정확히 매칭하도록 개선
  * AI 전송 실패 시 대기 큐 항목을 올바르게 제거하여 누적 방지

* **개선**
  * 인증/권한 오류 처리 시 연결을 즉시 끊지 않고 에러 메시지를 전송하도록 변경
  * WS 종료 시 대기 큐를 정리하여 리소스 유실 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->